### PR TITLE
Update Connect.pm

### DIFF
--- a/Connect.pm
+++ b/Connect.pm
@@ -474,14 +474,14 @@ sub _connectEvent {
 			my $clientId = $client->id;
 
 			# if we're playing, got a stop event, and current Connect device is us, then pause
-			if ( $client->isPlaying && ($result->{device}->{id} eq Plugins::Spotty::Connect::DaemonManager->idFromMac($clientId) || $result->{device}->{name} eq $client->name) && __PACKAGE__->isSpotifyConnect($client) ) {
+			if ( $client->isPlaying && !$client->isStopped() && !$client->isPaused() && ($result->{device}->{id} eq Plugins::Spotty::Connect::DaemonManager->idFromMac($clientId) || $result->{device}->{name} eq $client->name) && __PACKAGE__->isSpotifyConnect($client) ) {
 				main::INFOLOG && $log->is_info && $log->info("Spotify told us to pause: " . $client->id);
 
 				my $request = Slim::Control::Request->new( $client->id, ['pause', 1] );
 				$request->source(__PACKAGE__);
 				$request->execute();
 			}
-			elsif ( $client->isPlaying && ($result->{device}->{id} ne Plugins::Spotty::Connect::DaemonManager->idFromMac($clientId) && $result->{device}->{name} ne $client->name) && __PACKAGE__->isSpotifyConnect($client) ) {
+			elsif ( $client->isPlaying && !$client->isStopped() && !$client->isPaused() && ($result->{device}->{id} ne Plugins::Spotty::Connect::DaemonManager->idFromMac($clientId) && $result->{device}->{name} ne $client->name) && __PACKAGE__->isSpotifyConnect($client) ) {
 				main::INFOLOG && $log->is_info && $log->info("Spotify told us to pause, but current player is no longer the Connect target");
 
 				my $request = Slim::Control::Request->new( $client->id, ['pause', 1] );


### PR DESCRIPTION
## Fix: Prevent Spotty from sending Pause when player is stopped/paused

**Problem:**

When Spotify Connect instructs the player to stop (which Spotty interprets as a request to pause), the Spotty plugin sends a `pause` command to the LMS player core (`Slim::Player::StreamingController`). However, it did this even if the player was already stopped or paused. If the player was stopped (e.g., because the protocol handler doesn't support pause and converted it to a stop), receiving a subsequent `pause` command would trigger an "Invalid state" error in `StreamingController`.

**Solution:**

This commit modifies the `_connectEvent` function in `Spotty-Plugin/Connect.pm`. It adds checks using `$client->isStopped()` and `$client->isPaused()` to the conditions that trigger sending a `pause` command.

Now, Spotty will only send the `pause` command to the player if:
1.  It receives a `stop` command from Spotify Connect targeted at this player.
2.  The player is currently marked as playing (`$client->isPlaying`).
3.  The player is **not** already stopped (`!$client->isStopped()`).
4.  The player is **not** already paused (`!$client->isPaused()`).

This prevents the redundant `pause` command from being sent when the player is already in a stopped or paused state, resolving the "Invalid state" error in the player core.